### PR TITLE
Disentangle object context and index context.

### DIFF
--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -139,9 +139,11 @@ class UniqueObjectTest(unittest.TestCase):
             copy_specs = ["name", "id", "context"]
 
         a = D("foo", 1)
+        self.assertEqual(D._instances.len(all), 1)
 
         a.copy("bar", 2)
         a.copy(context="other")
+        self.assertEqual(D._instances.len(all), 3)
 
         with self.assertRaises(DuplicateIdException):
             a.copy("baz")
@@ -151,6 +153,7 @@ class UniqueObjectTest(unittest.TestCase):
 
         with uniqueness_context("other2"):
             a.copy()
+        self.assertEqual(D._instances.len(all), 4)
 
         with self.assertRaises(DuplicateObjectException):
             with uniqueness_context("other"):
@@ -166,7 +169,7 @@ class UniqueObjectIndexTest(unittest.TestCase):
         idx = UniqueObjectIndex(cls=C)
         idx.add("foo", 1)
         idx.add("bar", 2)
-        idx.add("test", 3, context="other")
+        idx.add("test", 3, context="other", index_context="other")
 
         return C, idx
 
@@ -296,7 +299,7 @@ class UniqueObjectIndexTest(unittest.TestCase):
         self.assertTrue("foo" in idx)
         self.assertTrue(idx.has("foo"))
 
-        idx.add("test", 1, context="newindex")
+        idx.add("test", 1, context="newindex", index_context="newindex")
         self.assertTrue("test" in idx)
         self.assertFalse(idx.has("test"))
 


### PR DESCRIPTION
This PR adds the way new `UniqueObject`'s are stored in the class wide instance storage.

Up until now, when a new object was created, it's very own index context was also used as the context of the instance storage. Those two are actually not connected but it was convenient in some situations to just use the same value.

However, this could lead to strange behavior when using `UniqueObjectIndex`es other than the instance storage. Generically, there should be no connection whatsoever between the context names. This PR achieves exactly that. As dependent packages might have relied on this "functionality", there should be a new release soon documenting this change.