### PR TITLE
Removed instance_cache clearing

### DIFF
--- a/order/unique.py
+++ b/order/unique.py
@@ -841,6 +841,12 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
 
         return int(id)
 
+    def _remove(self):
+        """
+        Explicitly removes this instance from the instance cache of this class.
+        """
+        self._instances.remove(self)
+
     def _copy_ref(self, kwargs, cls, specs):
         """
         This method implements the :py:meth:`CopyMixing._copy_ref` in case an inheriting class also

--- a/order/unique.py
+++ b/order/unique.py
@@ -693,13 +693,6 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
         # add the instance to the cache
         self._instances.add(self, context=self._context)
 
-    def __del__(self):
-        # remove from the instance cache
-        try:
-            self._remove()
-        except:
-            pass
-
     def _repr_parts(self):
         return [
             ("name", self.name),
@@ -847,15 +840,6 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
             raise TypeError("invalid id type: {}".format(id))
 
         return int(id)
-
-    def _remove(self):
-        """
-        Removes this instance from the instance cache if this class. This happens automatically in
-        the destructor, so in most cases one might not want to call this method manually. However,
-        the destructor is triggered when the reference count becomes 0, and not necessarily when
-        *del* is invoked.
-        """
-        self._instances.remove(self)
 
     def _copy_ref(self, kwargs, cls, specs):
         """

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -5,7 +5,6 @@ __all__ = ["UniqueObjectTest", "UniqueObjectIndexTest", "UniqueTreeTest"]
 
 
 import unittest
-from test.support import import_module
 
 from order import (
     UniqueObject, UniqueObjectIndex, uniqueness_context, unique_tree, DuplicateNameException,
@@ -55,7 +54,10 @@ class UniqueObjectTest(unittest.TestCase):
         C("foo", 2)
 
     def test_vanish(self):
-        cp = import_module("cloudpickle")
+        try:
+            import cloudpickle as cp
+        except ImportError as e:
+            raise unittest.SkipTest(e)
         import gc
 
         x = C2("foo", 222)

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -5,6 +5,7 @@ __all__ = ["UniqueObjectTest", "UniqueObjectIndexTest", "UniqueTreeTest"]
 
 
 import unittest
+from test.support import import_module
 
 from order import (
     UniqueObject, UniqueObjectIndex, uniqueness_context, unique_tree, DuplicateNameException,
@@ -42,11 +43,19 @@ class UniqueObjectTest(unittest.TestCase):
         with self.assertRaises(DuplicateIdException):
             C("bar", 1)
 
+    def test_uncache(self):
+        C = self.make_class()
+
+        foo = C("foo", 1)
+
+        with self.assertRaises(DuplicateNameException):
+            C("foo", 2)
+
+        foo._remove()
+        C("foo", 2)
+
     def test_vanish(self):
-        try:
-            import cloudpickle as cp
-        except ImportError as e:
-            raise unittest.SkipTest(e)
+        cp = import_module("cloudpickle")
         import gc
 
         x = C2("foo", 222)
@@ -105,6 +114,9 @@ class UniqueObjectTest(unittest.TestCase):
         self.assertEqual(C.get_instance("foo"), foo)
         self.assertEqual(C.get_instance(1), foo)
         self.assertEqual(C.get_instance(foo), foo)
+
+        foo._remove()
+        self.assertIsNone(C.get_instance("foo", default=None))
 
     def test_auto_id(self):
         C = self.make_class()


### PR DESCRIPTION
- it never operates as intended: the `OrderedDict` in `UniqueObjectIndex._indices` will always hold a reference; if these were switched to [`weakref.WeakValueDictionary`](https://docs.python.org/3/library/weakref.html#weakref.WeakValueDictionary), they would automatically removal the instance from the index and no explicit action would be needed.

- when a clone (created via (cloud)pickle) is garbage collected, it will 
remove the original from the index; added a test for this - will be skipped if `cloudpickle` is not available