### PR TITLE
Make UniqueObjectIndex pickleable

### DIFF
--- a/order/unique.py
+++ b/order/unique.py
@@ -182,10 +182,7 @@ class UniqueObjectIndex(CopyMixin):
 
         # seperate dicts to map names and ids to unique objects,
         # stored in a dict mapped to contexts
-        self._indices = collections.defaultdict(lambda: {
-            "names": collections.OrderedDict(),
-            "ids": collections.OrderedDict(),
-        })
+        self._indices = collections.defaultdict(self._indices_default_factory)
 
         # register indices for the default context
         self._indices[self.default_context]
@@ -196,6 +193,13 @@ class UniqueObjectIndex(CopyMixin):
 
         # save a dot access proxy for easy access of objects via name in the default context
         self._n = DotAccessProxy(self.get)
+
+    @staticmethod
+    def _indices_default_factory():
+        return {
+            "names": collections.OrderedDict(),
+            "ids": collections.OrderedDict(),
+        }
 
     def _copy_attribute_manual(self, inst, obj, spec):
         if spec.dst == "_indices":

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+scinum>=1.1.1
+six
+cloudpickle>=1.3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,3 +22,4 @@ from .test_process import *
 from .test_dataset import *
 from .test_config import *
 from .test_analysis import *
+from .test_pickle import *

--- a/tests/docker.sh
+++ b/tests/docker.sh
@@ -19,7 +19,7 @@ action() {
             bash
     else
         docker run --rm -t -v "$repo_dir":/root/order -w /root/order "$docker_image" \
-            bash -c "pip install -r requirements.txt && python -m unittest tests"
+            bash -c "pip install -r requirements_test.txt && python -m unittest tests"
     fi
 }
 action "$@"

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -6,7 +6,10 @@ __all__ = ["PickleTest"]
 
 import unittest
 
+import six
 import order
+
+from .util import skip_if, has_module
 
 
 def mk_obj(cls, arg0=None, name=None, id=123):
@@ -44,13 +47,12 @@ class PickleTest(unittest.TestCase):
             x2 = pickle.loads(y)
             self.assertEqual(x, x2)
 
+    @skip_if(six.PY2)
     def test_pickle(self):
         import pickle
         self.do_test(pickle)
 
+    @skip_if(not has_module("cloudpickle"))
     def test_cloudpickle(self):
-        try:
-            import cloudpickle
-        except ImportError as msg:
-            raise unittest.SkipTest(str(msg))
+        import cloudpickle
         self.do_test(cloudpickle)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+
+
+__all__ = ["PickleTest"]
+
+
+import unittest
+
+import order
+
+
+def mk_obj(cls, arg0=None, name=None, id=123):
+    if name is None:
+        name = cls.__name__.lower()
+    cls._instances.clear(cls._instances.ALL)
+    return cls(arg0, name, id) if arg0 else cls(name, id)
+
+
+class PickleTest(unittest.TestCase):
+
+    def do_test(self, pickle):
+        a = mk_obj(order.Analysis)
+        cp = mk_obj(order.Campaign)
+        ct = mk_obj(order.Category)
+        ch = mk_obj(order.Channel)
+        co = mk_obj(order.Config, arg0=cp)
+        d = mk_obj(order.Dataset)
+        p = mk_obj(order.Process)
+        s = mk_obj(order.Shift, name="shift_up")
+        v = mk_obj(order.Variable)
+
+        d.add_process(p)
+        cp.add_dataset(d)
+        co.add_process(p)
+        co.add_dataset(d)
+        co.add_channel(ch)
+        co.add_category(ct)
+        co.add_variable(v)
+        co.add_shift(s)
+        a.add_config(co)
+
+        for x in a, cp, ct, ch, co, d, p, s, v:
+            y = pickle.dumps(x)
+            x2 = pickle.loads(y)
+            self.assertEqual(x, x2)
+
+    def test_pickle(self):
+        import pickle
+        self.do_test(pickle)
+
+    def test_cloudpickle(self):
+        try:
+            import cloudpickle
+        except ImportError as msg:
+            raise unittest.SkipTest(str(msg))
+        self.do_test(cloudpickle)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,30 @@
+# coding: utf-8
+
+"""
+Helpers for tests.
+"""
+
+
+__all__ = ["skip_if", "has_module"]
+
+
+import functools
+import importlib
+
+
+def skip_if(b):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs) if not b else None
+        return wrapper
+    return decorator
+
+
+def has_module(name):
+    try:
+        importlib.import_module(name)
+    except ImportError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
Avoids `lambda` usage in a `pickle` reachable `defaultdict`.

Also adds some (simple) test for `pickle` (and `cloudpickle`, if installed).
However, the `pickle` (but not the `cloudpickle`) test fails for python 2.7 with `TypeError: can't pickle instancemethod objects`.