### PR TITLE
Add a small function for pretty print od.Processes including cross-se…

### DIFF
--- a/order/process.py
+++ b/order/process.py
@@ -107,7 +107,7 @@ class Process(UniqueObject, CopyMixin, AuxDataMixin, TagMixin, DataSourceMixin, 
                 process = process[0]
             if process.is_root_process:
                 if first:
-                    stream.write("\n")
+                    stream.write("\n".encode())
                 first = False
                 process.pretty_print(*args, **kwargs)
 
@@ -192,7 +192,7 @@ class Process(UniqueObject, CopyMixin, AuxDataMixin, TagMixin, DataSourceMixin, 
             xsec = self.xsecs.get(ecm)
             entry += "  " * _depth + (xsec.str(**kwargs) if xsec else "no cross-section")
 
-        stream.write(entry + "\n")
+        stream.write((entry + "\n").encode())
 
         # stop here when max_depth is reached
         if 0 <= max_depth <= _depth:

--- a/order/process.py
+++ b/order/process.py
@@ -10,7 +10,7 @@ __all__ = ["Process"]
 
 from scinum import Number
 
-from order.unique import UniqueObject, unique_tree
+from order.unique import UniqueObject, UniqueObjectIndex, unique_tree
 from order.mixins import CopyMixin, AuxDataMixin, TagMixin, DataSourceMixin, LabelMixin, ColorMixin
 from order.util import typed
 
@@ -90,6 +90,23 @@ class Process(UniqueObject, CopyMixin, AuxDataMixin, TagMixin, DataSourceMixin, 
         TagMixin.copy_specs + DataSourceMixin.copy_specs + LabelMixin.copy_specs + \
         ColorMixin.copy_specs
 
+    @classmethod
+    def pretty_print_all(cls, *args, **kwargs):
+        """ pretty_print_all(*args, contenxt=None, **kwargs)
+        Calls :py:meth:`pretty_print` of all root processes in the instance cache for *context*.
+        When *context* is *all*, root processes of all indices are printed.
+        """
+        context = kwargs.pop("context", None)
+        first = True
+        for process in cls._instances.values(context=context):
+            if context == UniqueObjectIndex.ALL:
+                process = process[0]
+            if process.is_root_process:
+                if first:
+                    print("")
+                first = False
+                process.pretty_print(*args, **kwargs)
+
     def __init__(self, name, id, xsecs=None, processes=None, color=None, label=None,
             label_short=None, is_data=False, tags=None, aux=None, context=None):
         UniqueObject.__init__(self, name, id, context=context)
@@ -150,3 +167,29 @@ class Process(UniqueObject, CopyMixin, AuxDataMixin, TagMixin, DataSourceMixin, 
         ecm, xsec = list(self.__class__.xsecs.fparse(self, {ecm: xsec}).items())[0]
         self.xsecs[ecm] = xsec
         return xsec
+
+    def pretty_print(self, ecm=None, offset=40, max_depth=-1, _depth=0, **kwargs):
+        """
+        Prints this process and potentially its subprocesses down to a maximum depth *max_depth* in
+        a structured fashion. When *ecm* is set, process cross section values are shown as well
+        with a maximum horizontal distance of *offset*. All *kwargs* are forwarded to the
+        :py:meth:`Number.str` methods of the cross section numbers.
+        """
+        # start the entry to print
+        entry = "| " * _depth + "> {} ({})".format(self.name, self.id)
+
+        # add cross-section values following an offset when ecm is set
+        if ecm is not None:
+            entry += " " * (offset - len(entry))
+            xsec = self.xsecs.get(ecm)
+            entry += "  " * _depth + (xsec.str(**kwargs) if xsec else "no cross-section")
+
+        print(entry)
+
+        # stop here when max_depth is reached
+        if 0 <= max_depth <= _depth:
+            return
+
+        for proc in self.processes:
+            proc.pretty_print(ecm=ecm, offset=offset, max_depth=max_depth, _depth=_depth + 1,
+                **kwargs)

--- a/order/process.py
+++ b/order/process.py
@@ -93,8 +93,9 @@ class Process(UniqueObject, CopyMixin, AuxDataMixin, TagMixin, DataSourceMixin, 
     @classmethod
     def pretty_print_all(cls, *args, **kwargs):
         """ pretty_print_all(*args, contenxt=None, **kwargs)
-        Calls :py:meth:`pretty_print` of all root processes in the instance cache for *context*.
-        When *context* is *all*, root processes of all indices are printed.
+        Calls :py:meth:`pretty_print` of all root processes in the instance cache for *context* and
+        forwards all *args* and *kwargs*. When *context* is *all*, root processes of all indices are
+        printed.
         """
         context = kwargs.pop("context", None)
         first = True

--- a/order/util.py
+++ b/order/util.py
@@ -372,3 +372,12 @@ class DotAccessProxy(object):
                 raise Exception("cannot set attribute, setter not defined on {}".format(
                     self.__class__.__name__))
             setter(attr, value)
+            
+            
+def pprint_processes(xs_key=13):
+    todo = [(p, 0) for p in od.Process._instances.values() if p.is_root_process]
+    while todo:
+        proc, depth = todo.pop(0)
+        prefix = ("" if depth else "\n") + "| " * depth + "> "
+        print("%-50s %s" % (prefix + proc.name, proc.xsecs.get(xs_key, None)))
+        todo = [(p, depth + 1) for p in proc.processes.values()] + todo

--- a/order/util.py
+++ b/order/util.py
@@ -375,7 +375,8 @@ class DotAccessProxy(object):
             
             
 def pprint_processes(xs_key=13):
-    todo = [(p, 0) for p in od.Process._instances.values() if p.is_root_process]
+    from order.process import Process
+    todo = [(p, 0) for p in Process._instances.values() if p.is_root_process]
     while todo:
         proc, depth = todo.pop(0)
         prefix = ("" if depth else "\n") + "| " * depth + "> "

--- a/order/util.py
+++ b/order/util.py
@@ -372,13 +372,3 @@ class DotAccessProxy(object):
                 raise Exception("cannot set attribute, setter not defined on {}".format(
                     self.__class__.__name__))
             setter(attr, value)
-            
-            
-def pprint_processes(xs_key=13):
-    from order.process import Process
-    todo = [(p, 0) for p in Process._instances.values() if p.is_root_process]
-    while todo:
-        proc, depth = todo.pop(0)
-        prefix = ("" if depth else "\n") + "| " * depth + "> "
-        print("%-50s %s" % (prefix + proc.name, proc.xsecs.get(xs_key, None)))
-        todo = [(p, depth + 1) for p in proc.processes.values()] + todo

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -4,6 +4,7 @@
 __all__ = ["ProcessTest"]
 
 
+from io import BytesIO
 import unittest
 
 from order import Process
@@ -67,3 +68,13 @@ class ProcessTest(unittest.TestCase):
 
         p2 = Process("parent2", 12, processes=[c])
         self.assertIn(p2, c.parent_processes)
+
+    def test_pretty_print(self):
+        a = Process("a", 100, xsecs={13: 12})
+        a.add_process("b", 101, xsecs={13: 1})
+
+        output = BytesIO()
+        a.pretty_print(13, offset=10, stream=output)
+
+        self.assertEqual(output.getvalue(),
+            "> a (100) 12.0 (no uncertainties)\n| > b (101)  1.0 (no uncertainties)\n")

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -76,5 +76,5 @@ class ProcessTest(unittest.TestCase):
         output = BytesIO()
         a.pretty_print(13, offset=10, stream=output)
 
-        self.assertEqual(output.getvalue(),
+        self.assertEqual(output.getvalue().decode("utf-8"),
             "> a (100) 12.0 (no uncertainties)\n| > b (101)  1.0 (no uncertainties)\n")


### PR DESCRIPTION
Also includes pretty printing of:

- all defined od.Processes
- process hierarchy
- cross-section

Example:

```python
... # lots of od.Process definitions here

if __name__ == "__main__":
    pprint_processes()
```

Output:

```shell
> ttV                                             None
| > ttW                                            None
| | > TTWJetsToLNu                                 0.196 (no uncertainties)
| | > TTWJetsToQQ                                  0.4049 (no uncertainties)
| > ttZ                                            None
| | > TTZToLL_M_1to10                              0.0822 (no uncertainties)
| | > TTZToLLNuNu_M_10                             0.2814 (no uncertainties)
| | > TTZToQQ                                      0.5868 (no uncertainties)

> ttVV                                            None
| > TTWW                                           0.006981 (no uncertainties)

> ttVH                                            None
| > TTWH                                           0.001582 (no uncertainties)
| > TTZH                                           0.001535 (no uncertainties)

> QCD                                             None
| > QCD_HT100to200                                 23700000.0 (no uncertainties)
| > QCD_HT200to300                                 1547000.0 (no uncertainties)
| > QCD_HT300to500                                 322600.0 (no uncertainties)
| > QCD_HT500to700                                 29980.0 (no uncertainties)
| > QCD_HT700to1000                                6334.0 (no uncertainties)
| > QCD_HT1000to1500                               1088.0 (no uncertainties)
| > QCD_HT1500to2000                               99.11 (no uncertainties)
| > QCD_HT2000toInf                                20.23 (no uncertainties)
```