### PR TITLE
unique_tree: add depth_first & include_self to walk functions

### DIFF
--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -555,6 +555,22 @@ class UniqueTreeTest(unittest.TestCase):
                 self.assertEqual(n, n1)
                 self.assertEqual(len(nodes), 0)
 
+        def walk(depth, this):
+            return [n for n, _, _ in n1.walk_nodes(
+                depth_first=depth,
+                include_self=this
+            )]
+
+        self.assertListEqual(walk(False, False), [n2, n3, n4])
+        self.assertListEqual(walk(False, True), [n1, n2, n3, n4])
+        self.assertListEqual(walk(True, False), [n2, n4, n3])
+        self.assertListEqual(walk(True, True), [n1, n2, n4, n3])
+
+        self.assertListEqual(
+            [n for n, _, _ in n4.walk_parent_nodes(include_self=True)],
+            [n4, n2, n1]
+        )
+
     def test_lookup(self):
         Node = self.make_class(deep_children=True, deep_parents=True)
         Node.default_uniqueness_context = "node_lookup"


### PR DESCRIPTION
Add `depth_first` and `include_self` parameters to the `walk` functions (children/parents) of `unique_tree`. They are both are disabled by default, retaining the current behavior. While the `depth_first` variable is rather straight forward, the `include_self` is rather counter-intuitive (since the node itself is not really a 0-th child/parent of itself), but I've already encountered several instances where is would helped a lot.

Also fixed the missing use of the `context` parameter for the `walk_parent_*` function.