### PR TITLE
[unique] UniqueObjectIndex: copy without name or id

### DIFF
--- a/order/unique.py
+++ b/order/unique.py
@@ -895,7 +895,7 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
         if "name" in kwargs or "id" in kwargs:
             return False
 
-        return True
+        raise ValueError("Can't copy {} without providing name or id.".format(type(self).__name__))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Copy should not be able to copy UniqueObjects to the same context without providing name or id.