### PR TITLE
[unique] UniqueObjectIndex: enables soft uniqueness checks

### DIFF
--- a/order/unique.py
+++ b/order/unique.py
@@ -436,11 +436,11 @@ class UniqueObjectIndex(CopyMixin):
 
         # check for duplicates in names
         if obj.name in self.names(context=context):
-            raise DuplicateNameException(self, obj.name, context)
+            raise DuplicateNameException(self.cls, obj.name, context)
 
         # check for duplicates in ids
         if obj.id in self.ids(context=context):
-            raise DuplicateIdException(self, obj.id, context)
+            raise DuplicateIdException(self.cls, obj.id, context)
 
         # add to the index
         self._indices[context]["names"][obj.name] = obj
@@ -601,16 +601,16 @@ class UniqueObjectIndexSoft(UniqueObjectIndex):
         # check for duplicates in names
         if obj.name in self.names(context=context):
             if self.soft_checking:
-                DuplicateNameWarning(self, obj.name, context)
+                DuplicateNameWarning(self.cls, obj.name, context)
             else:
-                raise DuplicateNameException(self, obj.name, context)
+                raise DuplicateNameException(self.cls, obj.name, context)
 
         # check for duplicates in ids
         if obj.id in self.ids(context=context):
             if self.soft_checking:
-                DuplicateIdWarning(self, obj.id, context)
+                DuplicateIdWarning(self.cls, obj.id, context)
             else:
-                raise DuplicateIdException(self, obj.id, context)
+                raise DuplicateIdException(self.cls, obj.id, context)
 
         # add to the index
         # invalidate if name already exists in index

--- a/order/unique.py
+++ b/order/unique.py
@@ -431,7 +431,7 @@ class UniqueObjectIndex(CopyMixin):
             context = kwargs.get("index_context") or kwargs.get("context") or self.default_context
             obj = args[0]
         else:
-            context = kwargs.pop("index_context", None) or self.cls.get_default_context()
+            context = kwargs.pop("index_context", None) or self.default_context
             obj = self.cls(*args, **kwargs)
 
         # check for duplicates in names

--- a/order/unique.py
+++ b/order/unique.py
@@ -431,7 +431,7 @@ class UniqueObjectIndex(CopyMixin):
             context = kwargs.get("index_context") or kwargs.get("context") or self.default_context
             obj = args[0]
         else:
-            context = kwargs.pop("index_context", None) or self.default_context
+            context = kwargs.pop("index_context", None) or self.cls.get_default_context()
             obj = self.cls(*args, **kwargs)
 
         # check for duplicates in names
@@ -780,15 +780,16 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
     def __init__(self, name, id, context=None):
         super(UniqueObject, self).__init__()
 
+        # check if default context needed
+        if context is None:
+            context = self.get_default_context()
+        self._context = context
+
         self._name = self.__class__.name.fparse(None, name)
         # check for auto_id
         if id == self.AUTO_ID:
             id = self.auto_id(name, context)
         self._id = self.__class__.id.fparse(None, id)
-        # check if default context needed
-        if context is None:
-            context = self.get_default_context()
-        self._context = context
 
         # add the instance to the cache
         self._instances.add(self, context=self._context)

--- a/order/unique.py
+++ b/order/unique.py
@@ -777,6 +777,9 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
     def __init__(self, name, id, context=None):
         super(UniqueObject, self).__init__()
 
+        self._name = None
+        self._id = None
+
         self._name = self.name.fparse(None, name)
         # check for auto_id
         if id == self.AUTO_ID:

--- a/order/unique.py
+++ b/order/unique.py
@@ -10,7 +10,6 @@ __all__ = [
     "DuplicateIdException", "uniqueness_context", "unique_tree",
 ]
 
-import sys
 import warnings
 import collections
 import contextlib
@@ -21,7 +20,7 @@ from order.mixins import CopyMixin
 from order.util import typed, make_list, class_id, DotAccessProxy
 
 
-this = sys.modules[__name__]
+soft_checking = False
 
 _no_default = object()
 
@@ -730,7 +729,7 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
         # use the typed parser to check the passed name and check for duplicates
         name = cls.name.fparse(None, name)
         if name in cls._instances.names(context=context):
-            if getattr(this, "soft_check", False):
+            if soft_checking:
                 DuplicateNameWarning(cls, name, context)
             else:
                 raise DuplicateNameException(cls, name, context)
@@ -742,7 +741,7 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
         # use the typed parser to check the passed id, check for duplicates and store it
         id = cls.id.fparse(None, id)
         if id in cls._instances.ids(context=context):
-            if getattr(this, "soft_check", False):
+            if soft_checking:
                 DuplicateIdWarning(cls, id, context)
             else:
                 raise DuplicateIdException(cls, id, context)

--- a/order/unique.py
+++ b/order/unique.py
@@ -20,8 +20,6 @@ from order.mixins import CopyMixin
 from order.util import typed, make_list, class_id, DotAccessProxy
 
 
-soft_checking = False
-
 _no_default = object()
 
 _not_found = object()
@@ -200,6 +198,8 @@ class UniqueObjectIndex(CopyMixin):
     """
 
     ALL = all
+
+    soft_checking = False
 
     copy_specs = [
         {"attr": "cls", "ref": True},
@@ -729,7 +729,7 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
         # use the typed parser to check the passed name and check for duplicates
         name = cls.name.fparse(None, name)
         if name in cls._instances.names(context=context):
-            if soft_checking:
+            if cls._instances.soft_checking:
                 DuplicateNameWarning(cls, name, context)
             else:
                 raise DuplicateNameException(cls, name, context)
@@ -741,7 +741,7 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
         # use the typed parser to check the passed id, check for duplicates and store it
         id = cls.id.fparse(None, id)
         if id in cls._instances.ids(context=context):
-            if soft_checking:
+            if cls._instances.soft_checking:
                 DuplicateIdWarning(cls, id, context)
             else:
                 raise DuplicateIdException(cls, id, context)

--- a/order/unique.py
+++ b/order/unique.py
@@ -780,14 +780,11 @@ class UniqueObject(six.with_metaclass(UniqueObjectMeta, UniqueObject)):
     def __init__(self, name, id, context=None):
         super(UniqueObject, self).__init__()
 
-        self._name = None
-        self._id = None
-
-        self._name = self.name.fparse(None, name)
+        self._name = self.__class__.name.fparse(None, name)
         # check for auto_id
         if id == self.AUTO_ID:
             id = self.auto_id(name, context)
-        self._id = self.id.fparse(None, id)
+        self._id = self.__class__.id.fparse(None, id)
         # check if default context needed
         if context is None:
             context = self.get_default_context()


### PR DESCRIPTION
These commits make it possible to have soft uniqueness checks.
If `soft_checking` is enabled on a `UniqueObjectIndex` instance, colliding `ids` or `names` only print a warning instead of an exception.